### PR TITLE
Add RedwoodSDK template for server-first React apps

### DIFF
--- a/definitions/rwsdk-basic.yaml
+++ b/definitions/rwsdk-basic.yaml
@@ -1,0 +1,7 @@
+name: "rwsdk-basic"
+description: "Full-stack RedwoodSDK app with React Server Components, server functions, and D1 database on Cloudflare Workers"
+base_reference: "rwsdk-reference"
+projectType: app
+
+package_patches:
+  name: "rwsdk-basic"

--- a/definitions/rwsdk-basic/prompts/selection.md
+++ b/definitions/rwsdk-basic/prompts/selection.md
@@ -1,0 +1,24 @@
+# RedwoodSDK Template
+
+## Use when:
+- User wants a **server-first React application** with React Server Components
+- User needs **D1 database** with direct SQL or Drizzle ORM
+- User asks for a **full-stack app** on Cloudflare Workers
+- User mentions **RedwoodSDK**, **rwsdk**, or **Redwood**
+- User needs server-rendered pages with selective client interactivity
+- User wants form-based mutations with server functions
+
+## Avoid when:
+- User wants a pure client-side SPA (use vite-reference instead)
+- User wants Next.js-style file-based routing
+- User needs real-time WebSocket features (use cfagents template)
+- User is building a presentation or slide deck
+
+## Built with:
+- **Framework**: RedwoodSDK (rwsdk) — server-first React on Cloudflare Workers
+- **Rendering**: React Server Components (default server, explicit "use client")
+- **Routing**: defineApp() with explicit route definitions in worker.tsx
+- **Database**: D1 (SQLite) via prepared statements or rwsdk/db with Kysely
+- **Styling**: Tailwind CSS v4
+- **Build**: Vite with rwsdk/vite + @cloudflare/vite-plugin
+- **Runtime**: Cloudflare Workers with nodejs_compat

--- a/definitions/rwsdk-basic/prompts/usage.md
+++ b/definitions/rwsdk-basic/prompts/usage.md
@@ -1,0 +1,145 @@
+# RedwoodSDK Template Usage
+
+## Overview
+Server-first React framework on Cloudflare Workers using React Server Components. All components are server components by default — use `"use client"` only for interactive components.
+
+## Tech
+- RedwoodSDK (rwsdk), React 19, Tailwind CSS v4, D1 (SQLite), TypeScript, Vite
+
+## File Structure
+```
+src/
+├── worker.tsx          # Entry point: defineApp() with all routes
+├── client.tsx          # Client hydration: initClient()
+└── app/
+    ├── Document.tsx    # HTML shell (must include client.tsx script)
+    ├── styles.css      # Tailwind: @import "tailwindcss"
+    ├── pages/          # Page components (server components by default)
+    ├── components/     # Shared components ("use client" for interactive ones)
+    └── functions.ts    # Server functions ("use server" for mutations)
+migrations/
+└── 0001_init.sql       # D1 schema
+```
+
+## Development Restrictions
+
+### CRITICAL Rules
+- **ALL components are server components by default** — they run on the server
+- **`"use client"` goes at the FILE level** — the entire file becomes a client module
+- **`"use server"` goes at the FILE level** — marks server functions callable from client
+- **Routes are defined ONLY in `src/worker.tsx`** using `defineApp()`
+- **Use `import { env } from "cloudflare:workers"`** — NEVER `process.env`
+- **Vite config must be `vite.config.mts`** (not `.ts`)
+- **Document MUST include** `<script>import("/src/client.tsx")</script>`
+- **CSS imports use `?url` suffix**: `import styles from "./styles.css?url"`
+- **Tailwind requires `environments: { ssr: {} }`** in vite.config.mts
+- **Generate timestamps in code** with `new Date().toISOString()` — NOT SQL defaults
+
+### CANNOT Modify
+- `vite.config.mts` structure (plugins order matters)
+- `src/client.tsx` (must be exactly `initClient()`)
+
+## Routing
+```typescript
+import { render, route, prefix } from "rwsdk/router";
+import { defineApp } from "rwsdk/worker";
+
+export default defineApp([
+  render(Document, [
+    route("/", HomePage),
+    route("/posts/:id", PostPage),        // params.id available
+    prefix("/admin", [
+      route("/", AdminDashboard),
+    ]),
+  ]),
+]);
+```
+
+### Route with inline data fetching:
+```typescript
+route("/posts/:id", async ({ params }) => {
+  const post = await getPost(params.id);
+  if (!post) return new Response("Not found", { status: 404 });
+  return <PostPage post={post} />;
+})
+```
+
+### API routes (HTTP method routing):
+```typescript
+route("/api/items", {
+  get: () => Response.json(items),
+  post: async ({ request }) => {
+    const body = await request.json();
+    return Response.json(newItem, { status: 201 });
+  },
+})
+```
+
+## Server Components (default)
+```typescript
+// No directive needed — server by default
+import { env } from "cloudflare:workers";
+
+export async function TodoList() {
+  const { results } = await env.DB.prepare("SELECT * FROM todos").all();
+  return <ul>{results.map((t: any) => <li key={t.id}>{t.title}</li>)}</ul>;
+}
+```
+
+## Client Components
+```typescript
+"use client";
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>;
+}
+```
+
+## Server Functions (mutations)
+```typescript
+// functions.ts
+"use server";
+import { env } from "cloudflare:workers";
+
+export async function addTodo(formData: FormData) {
+  const title = formData.get("title") as string;
+  const id = crypto.randomUUID();
+  await env.DB.prepare("INSERT INTO todos (id, title, completed, created_at) VALUES (?, ?, 0, ?)")
+    .bind(id, title, new Date().toISOString()).run();
+}
+```
+
+Client components call via form actions:
+```typescript
+"use client";
+import { addTodo } from "./functions";
+
+export function AddTodoForm() {
+  return (
+    <form action={addTodo}>
+      <input type="text" name="title" required />
+      <button type="submit">Add</button>
+    </form>
+  );
+}
+```
+
+## Database (D1)
+- Schema in `migrations/0001_init.sql`
+- Access via `env.DB.prepare("SQL").bind(values).run()`
+- Read: `.all()` returns `{ results }`, `.first()` returns single row
+- Write: `.run()` for INSERT/UPDATE/DELETE
+- Binding name: `DB` (configured in wrangler.jsonc)
+
+## Styling
+- Tailwind CSS v4 via `@tailwindcss/vite` plugin
+- Import in Document: `import styles from "./styles.css?url"`
+- Use Tailwind utility classes directly in JSX
+- Responsive, accessible design preferred
+
+## Bindings
+- `DB` — D1 database for persistent storage
+- `ASSETS` — Static asset serving
+- Access via `import { env } from "cloudflare:workers"`

--- a/reference/rwsdk-reference/migrations/0001_init.sql
+++ b/reference/rwsdk-reference/migrations/0001_init.sql
@@ -1,0 +1,7 @@
+-- Add your D1 schema here
+-- Example:
+-- CREATE TABLE IF NOT EXISTS items (
+--   id TEXT PRIMARY KEY,
+--   name TEXT NOT NULL,
+--   created_at TEXT NOT NULL
+-- );

--- a/reference/rwsdk-reference/package.json
+++ b/reference/rwsdk-reference/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "rwsdk-app",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite dev",
+    "preview": "vite preview",
+    "release": "npm run build && wrangler deploy"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-server-dom-webpack": "^19.1.0",
+    "rwsdk": "^1.0.0-beta.53",
+    "tailwindcss": "^4.1.0",
+    "@tailwindcss/vite": "^4.1.0"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.0.6",
+    "@cloudflare/workers-types": "^4.20250214.0",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "typescript": "^5.8.2",
+    "vite": "^6.3.5",
+    "wrangler": "^4.14.0"
+  }
+}

--- a/reference/rwsdk-reference/src/app/Document.tsx
+++ b/reference/rwsdk-reference/src/app/Document.tsx
@@ -1,0 +1,17 @@
+import styles from "./styles.css?url";
+
+export const Document: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <html lang="en">
+    <head>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <title>My App</title>
+      <link rel="stylesheet" href={styles} />
+      <link rel="modulepreload" href="/src/client.tsx" />
+    </head>
+    <body>
+      {children}
+      <script>import("/src/client.tsx")</script>
+    </body>
+  </html>
+);

--- a/reference/rwsdk-reference/src/app/pages/Home.tsx
+++ b/reference/rwsdk-reference/src/app/pages/Home.tsx
@@ -1,0 +1,10 @@
+export function Home() {
+  return (
+    <div className="max-w-2xl mx-auto py-16 px-4">
+      <h1 className="text-4xl font-bold text-gray-900 mb-4">Welcome</h1>
+      <p className="text-lg text-gray-600">
+        Your RedwoodSDK app is ready. Start building!
+      </p>
+    </div>
+  );
+}

--- a/reference/rwsdk-reference/src/app/styles.css
+++ b/reference/rwsdk-reference/src/app/styles.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/reference/rwsdk-reference/src/client.tsx
+++ b/reference/rwsdk-reference/src/client.tsx
@@ -1,0 +1,2 @@
+import { initClient } from "rwsdk/client";
+initClient();

--- a/reference/rwsdk-reference/src/worker.tsx
+++ b/reference/rwsdk-reference/src/worker.tsx
@@ -1,0 +1,10 @@
+import { render, route } from "rwsdk/router";
+import { defineApp } from "rwsdk/worker";
+import { Document } from "@/app/Document";
+import { Home } from "@/app/pages/Home";
+
+export default defineApp([
+  render(Document, [
+    route("/", Home),
+  ]),
+]);

--- a/reference/rwsdk-reference/tsconfig.json
+++ b/reference/rwsdk-reference/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "lib": ["DOM", "DOM.Iterable", "ESNext", "ES2022"],
+    "jsx": "react-jsx",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", ".tmp"]
+}

--- a/reference/rwsdk-reference/vite.config.mts
+++ b/reference/rwsdk-reference/vite.config.mts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import { redwood } from "rwsdk/vite";
+import { cloudflare } from "@cloudflare/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  environments: { ssr: {} },
+  plugins: [
+    cloudflare({ viteEnvironment: { name: "worker" } }),
+    redwood(),
+    tailwindcss(),
+  ],
+});

--- a/reference/rwsdk-reference/wrangler.jsonc
+++ b/reference/rwsdk-reference/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "rwsdk-app",
+  "main": "src/worker.tsx",
+  "compatibility_date": "2025-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "binding": "ASSETS"
+  },
+  "observability": {
+    "enabled": true
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "rwsdk-app-db",
+      "database_id": "local"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Introduces a new RedwoodSDK template (`rwsdk-basic`) for building full-stack server-first React applications on Cloudflare Workers with React Server Components, server functions, and D1 database integration.

## Key Changes
- **Template Definition**: Added `rwsdk-basic.yaml` configuration pointing to `rwsdk-reference` as the base
- **Documentation**: Created comprehensive `usage.md` guide covering:
  - Architecture overview (server-first React with RSC)
  - File structure and conventions
  - Critical development rules (server components by default, `"use client"` at file level, etc.)
  - Routing patterns with `defineApp()` and route handlers
  - Server components, client components, and server functions examples
  - D1 database access patterns
  - Styling with Tailwind CSS v4
  - Binding configuration
- **Selection Criteria**: Added `selection.md` to guide when this template should be used
- **Reference Implementation**: Complete working example including:
  - `vite.config.mts` with rwsdk, Cloudflare, and Tailwind plugins
  - `wrangler.jsonc` with D1 database and asset bindings
  - `tsconfig.json` with proper JSX and module resolution
  - `package.json` with React 19, rwsdk, Tailwind CSS v4, and build scripts
  - `src/worker.tsx` entry point with `defineApp()` routing
  - `src/client.tsx` client hydration setup
  - `src/app/Document.tsx` HTML shell with client script injection
  - `src/app/styles.css` Tailwind import
  - `src/app/pages/Home.tsx` example server component
  - `migrations/0001_init.sql` D1 schema template

## Notable Implementation Details
- Enforces server components as default with explicit `"use client"` for interactive components
- Uses `import { env } from "cloudflare:workers"` for environment/binding access (not `process.env`)
- CSS imports use `?url` suffix for proper asset handling
- Vite config includes `environments: { ssr: {} }` for SSR support
- Timestamps generated in code with `new Date().toISOString()` rather than SQL defaults
- Comprehensive routing examples covering page routes, parameterized routes, nested routes, and API endpoints

https://claude.ai/code/session_018NzaJmAbmXqnjYFngM6aMK