### PR TITLE
feat(voice-byok-runner): new voice template with VAD auto-stop and BY…

### DIFF
--- a/definitions/voice-byok-runner.yaml
+++ b/definitions/voice-byok-runner.yaml
@@ -1,0 +1,7 @@
+name: "voice-byok-runner"
+description: "Voice-first React SPA — VAD-based listening, gpt-4o-audio-preview via the platform's BYOK proxy. Single mic button, no chat thread."
+base_reference: "vite-reference"
+projectType: app
+# Patch package.json to match template name
+package_patches:
+  name: "voice-byok-runner"

--- a/definitions/voice-byok-runner/prompts/selection.md
+++ b/definitions/voice-byok-runner/prompts/selection.md
@@ -1,0 +1,28 @@
+# Template Selection — Voice BYOK Runner
+
+Voice-first React SPA. Single mic button. Server-side voice via OpenAI gpt-4o-audio-preview, routed through the platform's BYOK proxy with the user's stored OpenAI key.
+
+Use when:
+- The user asks for a voice assistant, voice coach, voice tutor, conversational AI, or any "voice-only" / "no text input" experience.
+- The interaction is real-time speech: user speaks, AI replies aloud, repeat.
+- A small, focused, mic-button-centric UI is preferred over a chat thread or transcript display.
+- Natural turn-taking is desired (tap once, speak, pause → AI responds; not press-and-hold).
+
+Avoid when:
+- The user wants a text chat UI as the primary interaction (use `c-code-react-runner` and add a small voice component if needed).
+- Voice is one feature among many — a richer general-purpose template with a voice component bolted on is more flexible.
+- The user explicitly wants browser-native voice (`window.speechSynthesis` / `SpeechRecognition`) instead of OpenAI quality. This template uses server-side OpenAI audio exclusively.
+
+Built with:
+- React + Vite + Tailwind (from `vite-reference` base)
+- Native `MediaRecorder` + `AudioContext` `AnalyserNode` for Voice Activity Detection (no `SpeechRecognition`)
+- Platform endpoints `/api/apps/:id/byok-token` (mint JWT) and `/api/proxy/external` (proxy to OpenAI with the user's stored key)
+- `gpt-4o-audio-preview` for audio-in/audio-out in a single round-trip per voice turn
+- Deterministic 401 retry (auto-refetch JWT once) and `serviceName` fallback chain (handles common variations like `OpenAI`, `openai`, `OPENAI`)
+
+Prerequisites the platform must satisfy at runtime (already true in production):
+- The HTMLRewriter injects `window.__STARTVIBECODE_API` and `window.__APP_ID` into served HTML
+- `AI_PROXY_JWT_SECRET` is configured on the worker
+- The user has stored an OpenAI key in Settings → External API Keys
+
+If those prereqs are missing, the component shows a graceful error message ("Voice service unavailable" / "Please add your OpenAI key in Settings"). It does NOT fall back to browser-native voice.

--- a/definitions/voice-byok-runner/prompts/usage.md
+++ b/definitions/voice-byok-runner/prompts/usage.md
@@ -1,0 +1,68 @@
+# Usage Guide — Voice BYOK Runner
+
+This template ships with a working voice-conversation component. Customize the visuals and the assistant's personality, but do NOT rewrite the BYOK + VAD plumbing — the wiring is correct as shipped.
+
+## What's already wired (DO NOT change unless you understand why)
+
+1. **Token mint on mount** — `src/components/VoiceConversation.tsx` fetches `${API_BASE}/api/apps/${APP_ID}/byok-token` once when the component mounts. The returned JWT is cached in a ref and used as `Authorization: Bearer ${token}` for all proxy calls. The platform validates the appId-origin binding before minting (cross-user defense).
+
+2. **Voice Activity Detection (VAD) auto-stop** — clicking the mic starts recording. A `requestAnimationFrame` loop runs `AnalyserNode.getFloatTimeDomainData()` and computes RMS amplitude. Recording stops automatically after `SILENCE_DURATION_MS` of silence following the user's first detected voice. **No manual second-tap.** A `MAX_RECORDING_MS` failsafe also caps any single recording.
+
+3. **gpt-4o-audio-preview round-trip** — each voice turn sends base64 webm audio, receives base64 wav audio, plays it back via `new Audio(URL.createObjectURL(...))`. ONE call per turn. No separate STT/TTS endpoints.
+
+4. **`serviceName` fallback chain** — if the proxy returns 404 (no key found for the placeholder `<EXACT_SERVICE_NAME>`), the component automatically retries with `OpenAI`, `openai`, `OPENAI` in order. Only after all candidates 404 does it surface "Please add your OpenAI key in Settings".
+
+5. **401 retry** — if the JWT expires mid-session (1-hour TTL), the component re-fetches `byok-token` once and retries the proxy call with the fresh token. Loops forbidden — exactly one retry.
+
+## What you SHOULD customize
+
+### Visual identity
+- **`src/pages/HomePage.tsx`** — the page that wraps `VoiceConversation`. Change layout, headline, branding, color scheme. The component itself is centered and self-contained; surrounding content is up to you.
+- **`src/components/VoiceConversation.tsx`** — the mic button JSX is at the bottom of the file (the `return (...)` block). Change the icon (currently 🎙), the label text, the button shape, the ring colors. **Do not rewrite the state machine or effect hooks** — they're correct as shipped.
+- Inline classes use Tailwind (already configured in the reference).
+
+### Assistant personality
+- The constant `SYSTEM_PROMPT` near the top of `VoiceConversation.tsx` reads `'You are a helpful voice assistant. Keep replies under 2 sentences.'` Replace with your assistant's persona. Keep it short — long voice replies feel sluggish.
+- The constant `VOICE` selects the OpenAI voice. Default `'alloy'`. Other options: `ash`, `ballad`, `coral`, `echo`, `sage`, `shimmer`.
+
+### VAD tuning (constants near top of `VoiceConversation.tsx`)
+| Constant | Default | Effect |
+|---|---|---|
+| `SILENCE_THRESHOLD` | `0.015` | RMS amplitude (0–1) below which counts as silence. Lower = more sensitive (catches quieter speakers); higher = more tolerant of background noise. |
+| `SILENCE_DURATION_MS` | `1500` | How long to hold below threshold AFTER the user's first detected voice before auto-stop. Lower = snappier turn-taking (1000ms feels brisk); higher = more pause-tolerant (2000ms allows hesitation mid-sentence). |
+| `MAX_RECORDING_MS` | `30000` | Failsafe ceiling on a single recording. If reached, recording stops regardless of VAD state. |
+
+### `serviceName` placeholder
+- `PRIMARY_SERVICE_NAME` is `'<EXACT_SERVICE_NAME>'`. **Replace this with the user's actual stored key name when generating an app for a specific user.** Ask the user, or check if they've mentioned it. If you don't know, leave the placeholder — the fallback chain catches the most common cases.
+
+## What you MUST NOT do
+
+- ❌ Don't replace `MediaRecorder` with `SpeechRecognition`. SpeechRecognition is browser-native STT (Chromium-only, lower quality, requires separate TTS). The whole point of this template is server-side `gpt-4o-audio-preview` doing STT + reasoning + TTS in one call.
+- ❌ Don't replace `gpt-4o-audio-preview` audio playback with `window.speechSynthesis`. That's browser-native TTS and bypasses the OpenAI voice quality the user is paying for.
+- ❌ Don't add `credentials: 'include'` to the proxy fetch. Auth is `Authorization: Bearer ${byokToken}` only. Cookies don't travel cross-subdomain anyway, and the platform's CSRF middleware would block cookie-bearing POSTs from sandbox origins.
+- ❌ Don't construct relative URLs (`fetch('/api/proxy/external')`). From a sandbox subdomain those hit the user's own Vite server, not the platform. Always use `${API_BASE}/api/proxy/external` where `API_BASE = window.__STARTVIBECODE_API || ''`.
+- ❌ Don't add a chat-history UI, message list, or transcript display unless the user explicitly asks. This template is voice-first; visual output is a state indicator (idle/listening/processing/speaking/error), not a transcript.
+- ❌ Don't wrap the whole app in extra routes or providers unless the user asks for multi-page navigation. The single-page voice landing is the design.
+
+## Error UX (already handled by the component)
+
+| Status | User-visible behavior |
+|---|---|
+| Mounting | Button shows "Connecting…" while byok-token mint is in flight. Disabled. |
+| Mic permission denied | "Please allow microphone access in your browser settings." Tap to retry. |
+| 401 from proxy (token expired) | Auto-refetches once and retries the proxy call. If still 401: "Voice session expired, please refresh the page." |
+| 404 from proxy (no matching key) | Tries the `serviceName` fallbacks. If all 404: "Please add your OpenAI key in Settings → External API Keys to use voice features." |
+| Other 5xx / network error | "Voice service unavailable. Please try again." |
+
+The component never surfaces raw error strings (`event.error`, fetch errors, etc.) to the user — only the friendly messages above.
+
+## File overview
+
+```
+src/
+├── pages/HomePage.tsx           ← page wrapper; customize visuals here
+└── components/
+    └── VoiceConversation.tsx    ← the mic + state + BYOK + VAD; tune constants near the top
+```
+
+The reference scaffold provides everything else (Vite, React, Tailwind, ErrorBoundary, etc.). You don't need to add any new files for a working voice app — just customize what's already here.

--- a/definitions/voice-byok-runner/src/components/VoiceConversation.tsx
+++ b/definitions/voice-byok-runner/src/components/VoiceConversation.tsx
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// =====================================================================
+// VAD (Voice Activity Detection) tuning — adjust these to make detection
+// more or less sensitive. See prompts/usage.md for guidance.
+// =====================================================================
+const SILENCE_THRESHOLD = 0.015;     // RMS amplitude (0-1); below this counts as silence
+const SILENCE_DURATION_MS = 1500;    // hold below threshold this long AFTER first voice → auto-stop
+const MAX_RECORDING_MS = 30000;      // failsafe ceiling on a single recording
+
+// =====================================================================
+// Service-name fallback chain — tried in order on 404 from the proxy.
+// AI builder should replace <EXACT_SERVICE_NAME> with the user's actual
+// stored key name in Settings → External API Keys. If left as placeholder,
+// the fallback chain catches the most common variations.
+// =====================================================================
+const PRIMARY_SERVICE_NAME = '<EXACT_SERVICE_NAME>';
+const SERVICE_NAME_FALLBACKS = ['OpenAI', 'openai', 'OPENAI'];
+
+// =====================================================================
+// Assistant personality — customize for your app's persona.
+// =====================================================================
+const SYSTEM_PROMPT = 'You are a helpful voice assistant. Keep replies under 2 sentences.';
+const VOICE = 'alloy'; // alloy | ash | ballad | coral | echo | sage | shimmer
+
+type Status = 'connecting' | 'idle' | 'listening' | 'processing' | 'speaking' | 'error';
+
+interface ByokTokenResponse {
+  data: { token: string; expiresIn: number };
+}
+
+interface ChatCompletion {
+  choices: Array<{ message: { audio?: { data: string } } }>;
+}
+
+declare global {
+  interface Window {
+    __STARTVIBECODE_API?: string;
+    __APP_ID?: string;
+  }
+}
+
+export default function VoiceConversation() {
+  const [status, setStatus] = useState<Status>('connecting');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Refs (NOT useState — recording objects in state cause re-render loops).
+  const byokTokenRef = useRef<string | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const recordStartRef = useRef<number>(0);
+  const lastVoiceAtRef = useRef<number>(0);
+  const voiceDetectedRef = useRef<boolean>(false);
+
+  const API_BASE =
+    typeof window !== 'undefined' ? window.__STARTVIBECODE_API || '' : '';
+  const APP_ID =
+    typeof window !== 'undefined'
+      ? window.__APP_ID || (import.meta.env.VITE_APP_ID as string | undefined)
+      : undefined;
+
+  // ── 1. Mint BYOK token ───────────────────────────────────────────────
+  const fetchByokToken = useCallback(async (): Promise<string | null> => {
+    if (!APP_ID) return null;
+    try {
+      const r = await fetch(`${API_BASE}/api/apps/${APP_ID}/byok-token`);
+      if (!r.ok) return null;
+      const json = (await r.json()) as ByokTokenResponse;
+      byokTokenRef.current = json.data.token;
+      return json.data.token;
+    } catch {
+      return null;
+    }
+  }, [API_BASE, APP_ID]);
+
+  useEffect(() => {
+    if (!APP_ID) {
+      setStatus('error');
+      setErrorMessage('App ID unavailable. Please refresh the page.');
+      return;
+    }
+    fetchByokToken().then((tok) => {
+      if (tok) {
+        setStatus('idle');
+      } else {
+        setStatus('error');
+        setErrorMessage('Voice service unavailable. Please refresh.');
+      }
+    });
+  }, [APP_ID, fetchByokToken]);
+
+  // ── 2. Cleanup on unmount ────────────────────────────────────────────
+  useEffect(() => {
+    return cleanupRecording;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function cleanupRecording() {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    if (audioCtxRef.current) {
+      audioCtxRef.current.close().catch(() => {});
+      audioCtxRef.current = null;
+    }
+    analyserRef.current = null;
+  }
+
+  // ── 3. VAD loop ──────────────────────────────────────────────────────
+  // Runs every animation frame while recording. Stops when:
+  //   - voice was heard at least once AND silence has held for SILENCE_DURATION_MS
+  //   - OR total recording time hit MAX_RECORDING_MS (failsafe)
+  // Pre-voice silence does NOT count; a slow-to-start user is not cut off.
+  const vadLoop = useCallback(() => {
+    const analyser = analyserRef.current;
+    const recorder = recorderRef.current;
+    if (!analyser || !recorder || recorder.state !== 'recording') return;
+
+    const buf = new Float32Array(analyser.fftSize);
+    analyser.getFloatTimeDomainData(buf);
+    let sumSq = 0;
+    for (let i = 0; i < buf.length; i++) sumSq += buf[i] * buf[i];
+    const rms = Math.sqrt(sumSq / buf.length);
+
+    const now = performance.now();
+    if (rms > SILENCE_THRESHOLD) {
+      lastVoiceAtRef.current = now;
+      voiceDetectedRef.current = true;
+    }
+
+    const elapsed = now - recordStartRef.current;
+    const sinceVoice = now - lastVoiceAtRef.current;
+
+    if (voiceDetectedRef.current && sinceVoice >= SILENCE_DURATION_MS) {
+      recorder.stop();
+      return;
+    }
+    if (elapsed >= MAX_RECORDING_MS) {
+      recorder.stop();
+      return;
+    }
+    rafRef.current = requestAnimationFrame(vadLoop);
+  }, []);
+
+  // ── 4. Start recording ───────────────────────────────────────────────
+  async function startRecording() {
+    if (!byokTokenRef.current) return;
+    setErrorMessage(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const mime = MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : '';
+      const recorder = mime
+        ? new MediaRecorder(stream, { mimeType: mime })
+        : new MediaRecorder(stream);
+      recorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      recorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const heardVoice = voiceDetectedRef.current;
+        cleanupRecording();
+        voiceDetectedRef.current = false;
+        if (heardVoice && blob.size > 0) {
+          processAudio(blob);
+        } else {
+          setStatus('idle');
+        }
+      };
+
+      // Wire AnalyserNode for VAD on the SAME stream.
+      const audioCtx = new AudioContext();
+      audioCtxRef.current = audioCtx;
+      const source = audioCtx.createMediaStreamSource(stream);
+      const analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 2048;
+      source.connect(analyser);
+      analyserRef.current = analyser;
+
+      const t0 = performance.now();
+      recordStartRef.current = t0;
+      lastVoiceAtRef.current = t0;
+      voiceDetectedRef.current = false;
+
+      recorder.start();
+      setStatus('listening');
+      rafRef.current = requestAnimationFrame(vadLoop);
+    } catch (err) {
+      console.error('Mic access failed', err);
+      setStatus('error');
+      setErrorMessage('Please allow microphone access in your browser settings.');
+    }
+  }
+
+  // ── 5. Process recorded audio: BYOK proxy with serviceName fallback ──
+  async function processAudio(blob: Blob) {
+    setStatus('processing');
+    try {
+      const b64 = await blobToBase64(blob);
+      const candidates = [PRIMARY_SERVICE_NAME, ...SERVICE_NAME_FALLBACKS];
+
+      // Try each serviceName candidate; on 404, advance.
+      // On 401, re-mint token and retry the full chain ONCE.
+      let res = await tryCandidates(candidates, b64, byokTokenRef.current!);
+      if (res.status === 401) {
+        const fresh = await fetchByokToken();
+        if (fresh) res = await tryCandidates(candidates, b64, fresh);
+      }
+
+      if (res.status === 404) {
+        setStatus('error');
+        setErrorMessage(
+          'Please add your OpenAI key in Settings → External API Keys to use voice features.',
+        );
+        return;
+      }
+      if (res.status === 401) {
+        setStatus('error');
+        setErrorMessage('Voice session expired, please refresh the page.');
+        return;
+      }
+      if (!res.ok) {
+        setStatus('error');
+        setErrorMessage('Voice service unavailable. Please try again.');
+        return;
+      }
+
+      const data = (await res.json()) as ChatCompletion;
+      const audioB64 = data.choices[0]?.message.audio?.data;
+      if (!audioB64) {
+        setStatus('error');
+        setErrorMessage('No audio in response. Please try again.');
+        return;
+      }
+
+      const bytes = Uint8Array.from(atob(audioB64), (c) => c.charCodeAt(0));
+      const url = URL.createObjectURL(new Blob([bytes], { type: 'audio/wav' }));
+      const audio = new Audio(url);
+      audio.onended = () => {
+        URL.revokeObjectURL(url);
+        setStatus('idle');
+      };
+      audio.onerror = () => {
+        URL.revokeObjectURL(url);
+        setStatus('error');
+        setErrorMessage('Audio playback failed.');
+      };
+      setStatus('speaking');
+      await audio.play();
+    } catch (err) {
+      console.error('Voice processing failed', err);
+      setStatus('error');
+      setErrorMessage('Voice service unavailable. Please try again.');
+    }
+  }
+
+  async function tryCandidates(
+    candidates: string[],
+    b64: string,
+    token: string,
+  ): Promise<Response> {
+    let last: Response | null = null;
+    for (const serviceName of candidates) {
+      const res = await callProxy(b64, token, serviceName);
+      last = res;
+      if (res.status !== 404) return res;
+    }
+    return last!; // last 404 if all candidates failed
+  }
+
+  function callProxy(
+    audioB64: string,
+    token: string,
+    serviceName: string,
+  ): Promise<Response> {
+    return fetch(`${API_BASE}/api/proxy/external`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        serviceName,
+        url: 'https://api.openai.com/v1/chat/completions',
+        method: 'POST',
+        body: {
+          model: 'gpt-4o-audio-preview',
+          modalities: ['text', 'audio'],
+          audio: { voice: VOICE, format: 'wav' },
+          messages: [
+            { role: 'system', content: SYSTEM_PROMPT },
+            {
+              role: 'user',
+              content: [
+                { type: 'input_audio', input_audio: { data: audioB64, format: 'webm' } },
+              ],
+            },
+          ],
+        },
+      }),
+    });
+  }
+
+  function blobToBase64(blob: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const r = new FileReader();
+      r.onload = () => resolve((r.result as string).split(',')[1]);
+      r.onerror = () => reject(r.error);
+      r.readAsDataURL(blob);
+    });
+  }
+
+  // ── 6. UI ────────────────────────────────────────────────────────────
+  function handleClick() {
+    if (status === 'idle' && byokTokenRef.current) {
+      startRecording();
+    } else if (status === 'error') {
+      // Recover: clear error and re-check token
+      setErrorMessage(null);
+      if (byokTokenRef.current) {
+        setStatus('idle');
+      } else {
+        setStatus('connecting');
+        fetchByokToken().then((tok) => setStatus(tok ? 'idle' : 'error'));
+      }
+    }
+  }
+
+  const buttonLabel: Record<Status, string> = {
+    connecting: 'Connecting…',
+    idle: 'Tap to talk',
+    listening: 'Listening…',
+    processing: 'Thinking…',
+    speaking: 'Speaking…',
+    error: 'Tap to retry',
+  };
+
+  const ringClass: Record<Status, string> = {
+    connecting: 'border-zinc-600',
+    idle: 'border-zinc-500 hover:border-zinc-300',
+    listening: 'border-blue-500 ring-4 ring-blue-500/20',
+    processing: 'border-amber-500',
+    speaking: 'border-emerald-500 ring-4 ring-emerald-500/30 animate-pulse',
+    error: 'border-red-500',
+  };
+
+  const interactive = status === 'idle' || status === 'error';
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={!interactive}
+        aria-label={buttonLabel[status]}
+        className={[
+          'w-48 h-48 rounded-full border-4 bg-zinc-900 text-zinc-100',
+          'flex flex-col items-center justify-center gap-2',
+          'transition-all duration-200',
+          interactive ? 'cursor-pointer hover:scale-[1.02]' : 'cursor-not-allowed opacity-90',
+          ringClass[status],
+        ].join(' ')}
+      >
+        <span className="text-5xl" aria-hidden="true">🎙</span>
+        <span className="text-sm font-medium">{buttonLabel[status]}</span>
+      </button>
+
+      {errorMessage && (
+        <p role="alert" className="text-sm text-red-400 text-center max-w-xs">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/definitions/voice-byok-runner/src/pages/HomePage.tsx
+++ b/definitions/voice-byok-runner/src/pages/HomePage.tsx
@@ -1,0 +1,16 @@
+import VoiceConversation from '@/components/VoiceConversation';
+
+export function HomePage() {
+  return (
+    <main className="min-h-screen bg-zinc-950 text-zinc-100 flex flex-col items-center justify-center p-8 gap-8">
+      <header className="text-center max-w-md">
+        <h1 className="text-3xl font-semibold tracking-tight mb-2">Voice Assistant</h1>
+        <p className="text-zinc-400 text-sm leading-relaxed">
+          Tap the mic, speak naturally, then pause. The assistant listens, thinks,
+          and replies aloud.
+        </p>
+      </header>
+      <VoiceConversation />
+    </main>
+  );
+}


### PR DESCRIPTION
…OK proxy flow

- Single mic button, voice activity detection auto-stop (~1.5s silence after speaking)
- Mints byok-token on mount, calls /api/proxy/external with Authorization: Bearer
- gpt-4o-audio-preview model, base64 audio in/out
- serviceName fallback chain (placeholder + OpenAI/openai/OPENAI variants on 404)
- 401 token-refresh retry once before showing session-expired
- Tunable VAD constants near top of component for easy adjustment